### PR TITLE
Improve language redirection with locale matcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     <meta name="twitter:title" content="Here's Mars">
     <meta name="twitter:description" content="Mars Contact Page. Really nice to meet you, keep in touch nya!">
     <meta name="twitter:image" content="https://maao.cc/og-image/maao.cc-og-en.png">
+
+    <script src="https://unpkg.com/@kuriyota/locale-matcher@0.1.0/dist/index.umd.js"></script>"
     
     <style>
         body {
@@ -51,25 +53,15 @@
         const preferredLang = localStorage.getItem('preferredLanguage');
         const browserLang = (navigator.language || navigator.userLanguage).split('-')[0];
     
-        function redirectToLanguage(lang) {
-            if (lang === 'en') {
-                window.location.href = './en/';
-            } else if (lang === 'zh') {
-                window.location.href = './zh/';
-            } else if (lang === 'it') {
-                window.location.href = './it/';
-            } else if (lang === 'ja' || lang === 'jp') {
-                window.location.href = './jp/';
-            } else {
-                window.location.href = './en/';
-            }
-        }
-    
         if (preferredLang) {
-            redirectToLanguage(preferredLang);
+            window.location.href = `./${preferredLang}/`;
         } else {
-            redirectToLanguage(browserLang);
-            localStorage.setItem('preferredLanguage', browserLang);
+            const supportedLanguages = ['en', 'zh', 'it', 'ja'];
+            const matchedLanguages = LocaleMatcher.matchLanguages(browserLang, supportedLanguages);
+            const bestMatch = matchedLanguages.length > 0 ? matchedLanguages[0] : 'en';
+            
+            window.location.href = `./${bestMatch}/`;
+            localStorage.setItem('preferredLanguage', bestMatch);
         }
     
         setTimeout(() => {


### PR DESCRIPTION
Replaces manual language redirection logic with @kuriyota/locale-matcher for better language matching. Simplifies code and ensures users are redirected to the best supported language based on their browser settings.